### PR TITLE
セッション名の重複処理を改善

### DIFF
--- a/ninja.sh
+++ b/ninja.sh
@@ -14,6 +14,24 @@ check_session() {
   fi
 }
 
+# 重複セッション名の処理関数
+generate_unique_session_name() {
+  local base_name="$1"
+  local new_name="$base_name"
+  local counter=1
+
+  # ベース名が既に存在するか確認
+  if check_session "$new_name"; then
+    # 連番付きの名前を試す
+    while check_session "${base_name}(${counter})"; do
+      ((counter++))
+    done
+    new_name="${base_name}(${counter})"
+  fi
+
+  echo "$new_name"
+}
+
 ninja() {
   # ヘルプオプションの早期チェック
   if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
@@ -27,7 +45,9 @@ ninja() {
     echo "  --log <log_file>    Specify the log file path."
     echo "  -h, --help            Show this help message and exit."
     echo ""
-    echo "Default session name format:<ctrl3348>MMDD_HHMMSS"
+    echo "Note: If the specified session name already exists, (n) will be appended"
+    echo "      where n is the next available number."
+    echo "Default session name format: YYYYMMDD_HHMMSS"
     return 0
   fi
 
@@ -76,11 +96,13 @@ ninja() {
   fi
 
   if [[ -n "$command" ]]; then
-    # セッション名の重複チェック
-    if check_session "$session_name"; then
-      # アクティブなセッションが存在する場合、デフォルト名を使用
-      echo "Session \"$session_name\" already exists, using default session name instead."
-      session_name="$default_session_name"
+    local original_name="$session_name"
+    # セッション名の重複をチェックし、必要に応じて新しい名前を生成
+    if [[ "$session_name" != "$default_session_name" ]]; then
+      session_name=$(generate_unique_session_name "$session_name")
+      if [[ "$session_name" != "$original_name" ]]; then
+        echo "Session \"$original_name\" already exists, using \"$session_name\" instead."
+      fi
     fi
 
     # セッション情報の表示


### PR DESCRIPTION
# 変更内容

## 機能追加
- セッション名が重複した場合に連番を付与する機能を追加
  - 例: `test` -> `test(1)` -> `test(2)`
- セッション情報の出力を改善
  - 重複時のメッセージをより明確に

## その他の改善
- ヘルプメッセージに連番付与の説明を追加
- タイムスタンプの形式説明を修正

# 解決するIssue
- Fixes #2 過去と同じセッション名を指定すると，デフォルトのセッション名に上書きされる
- Fixes #3 ninjaコマンドを実行したときに，実行開始したセッションの情報が出力されてほしい
- Fixes #9 重複した際のセッション名の変更

# 動作確認項目
- [ ] 通常のセッション作成
- [ ] 重複するセッション名を指定した場合の連番付与
- [ ] セッション情報の出力フォーマット
- [ ] killed状態のセッションの扱い
